### PR TITLE
metrics: add `InstrumentedQueue`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p modules/trace/.jvm/target modules/trace/.js/target modules/metrics/jvm/target modules/trace/.native/target project/target
+        run: mkdir -p modules/trace/.jvm/target modules/trace/.js/target modules/metrics/native/target modules/metrics/jvm/target modules/metrics/js/target modules/trace/.native/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar modules/trace/.jvm/target modules/trace/.js/target modules/metrics/jvm/target modules/trace/.native/target project/target
+        run: tar cf targets.tar modules/trace/.jvm/target modules/trace/.js/target modules/metrics/native/target modules/metrics/jvm/target modules/metrics/js/target modules/trace/.native/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ libraryDependencies ++= Seq(
 
 ### 1) `IOMetrics` - cats-effect runtime metrics
 
+> [!IMPORTANT]
+> `IOMetrics` instrumentation is available only on JVM platform.
+
+Example:
 ```scala
 import cats.effect.{IO, IOApp}
 import org.typelevel.otel4s.experimental.metrics._
@@ -41,6 +45,42 @@ object Main extends IOApp.Simple {
 ```
 
 The metrics can be visualized in Grafana using this [dashboard][grafana-ce-dashboard].
+
+### 2) `InstrumentedQueue` - the instrumentation for `cats.effect.std.Queue`
+
+The provided metrics:
+- `cats.effect.std.queue.size` - the current number of the elements in the queue
+- `cats.effect.std.queue.enqueued` - the total (lifetime) number of enqueued elements
+- `cats.effect.std.queue.offer.blocked` - the current number of the 'blocked' offerers
+- `cats.effect.std.queue.take.blocked`- the current number of the 'blocked' takers
+
+
+Example:
+```scala
+import cats.effect.{IO, IOApp}
+import cats.effect.std.Queue
+import org.typelevel.otel4s.{Attribute, Attributes}
+import org.typelevel.otel4s.experimental.metrics._
+import org.typelevel.otel4s.oteljava.OtelJava
+
+object Main extends IOApp.Simple {
+
+  def run: IO[Unit] =
+    OtelJava.autoConfigured[IO]().use { otel4s =>
+      otel4s.meterProvider.get("service.meter").flatMap { implicit meter =>
+        val attributes = Attributes(
+          Attribute("queue.type", "unbounded"),
+          Attribute("queue.name", "auth events")
+        )
+        for {
+          source <- Queue.unbounded[IO, String]
+          queue <- InstrumentedQueue(source, attributes = attributes)
+          // use the instrumented queue
+        } yield ()
+      }
+    }
+}
+```
 
 ## Trace - getting started
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,9 @@ object Main extends IOApp.Simple {
   def run: IO[Unit] =
     OtelJava.autoConfigured[IO]().use { otel4s =>
       otel4s.meterProvider.get("service.meter").flatMap { implicit meter =>
-        val attributes = Attributes(
-          Attribute("queue.type", "unbounded"),
-          Attribute("queue.name", "auth events")
-        )
+        val attributes = Attributes(Attribute("queue.name", "auth events"))
         for {
-          source <- Queue.unbounded[IO, String]
-          queue <- InstrumentedQueue(source, attributes = attributes)
+          queue <- InstrumentedQueue.unbounded[IO, String](attributes = attributes)
           // use the instrumented queue
         } yield ()
       }

--- a/build.sbt
+++ b/build.sbt
@@ -39,17 +39,19 @@ lazy val root = tlCrossRootProject
   .settings(name := "otel4s-experimental")
   .aggregate(metrics, trace)
 
-lazy val metrics = crossProject(JVMPlatform)
+lazy val metrics = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Full)
   .in(file("modules/metrics"))
   .settings(munitDependencies)
   .settings(
-    name        := "otel4s-experimental-metrics",
-    Test / fork := true,
+    name := "otel4s-experimental-metrics",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "otel4s-core-metrics"        % Versions.Otel4s,
       "org.typelevel" %%% "otel4s-sdk-metrics-testkit" % Versions.Otel4s % Test
     )
+  )
+  .jvmSettings(
+    Test / fork := true
   )
 
 lazy val trace = crossProject(JVMPlatform, JSPlatform, NativePlatform)

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,6 @@ The provided metrics:
 - `cats.effect.std.queue.offer.blocked` - the current number of the 'blocked' offerers
 - `cats.effect.std.queue.take.blocked`- the current number of the 'blocked' takers
 
-
 Example:
 ```scala
 import cats.effect.{IO, IOApp}
@@ -68,13 +67,9 @@ object Main extends IOApp.Simple {
   def run: IO[Unit] =
     OtelJava.autoConfigured[IO]().use { otel4s =>
       otel4s.meterProvider.get("service.meter").flatMap { implicit meter =>
-        val attributes = Attributes(
-          Attribute("queue.type", "unbounded"),
-          Attribute("queue.name", "auth events")
-        )
+        val attributes = Attributes(Attribute("queue.name", "auth events"))
         for {
-          source <- Queue.unbounded[IO, String]
-          queue <- InstrumentedQueue(source, attributes = attributes)
+          queue <- InstrumentedQueue.unbounded[IO, String](attributes = attributes)
           // use the instrumented queue
         } yield ()
       }

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,10 @@ libraryDependencies ++= Seq(
 
 ### 1) `IOMetrics` - cats-effect runtime metrics
 
+> [!IMPORTANT]
+> `IOMetrics` instrumentation is available only on JVM platform.
+
+Example:
 ```scala mdoc:silent
 import cats.effect.{IO, IOApp}
 import org.typelevel.otel4s.experimental.metrics._
@@ -41,6 +45,42 @@ object Main extends IOApp.Simple {
 ```
 
 The metrics can be visualized in Grafana using this [dashboard][grafana-ce-dashboard].
+
+### 2) `InstrumentedQueue` - the instrumentation for `cats.effect.std.Queue`
+
+The provided metrics:
+- `cats.effect.std.queue.size` - the current number of the elements in the queue
+- `cats.effect.std.queue.enqueued` - the total (lifetime) number of enqueued elements
+- `cats.effect.std.queue.offer.blocked` - the current number of the 'blocked' offerers
+- `cats.effect.std.queue.take.blocked`- the current number of the 'blocked' takers
+
+
+Example:
+```scala
+import cats.effect.{IO, IOApp}
+import cats.effect.std.Queue
+import org.typelevel.otel4s.{Attribute, Attributes}
+import org.typelevel.otel4s.experimental.metrics._
+import org.typelevel.otel4s.oteljava.OtelJava
+
+object Main extends IOApp.Simple {
+
+  def run: IO[Unit] =
+    OtelJava.autoConfigured[IO]().use { otel4s =>
+      otel4s.meterProvider.get("service.meter").flatMap { implicit meter =>
+        val attributes = Attributes(
+          Attribute("queue.type", "unbounded"),
+          Attribute("queue.name", "auth events")
+        )
+        for {
+          source <- Queue.unbounded[IO, String]
+          queue <- InstrumentedQueue(source, attributes = attributes)
+          // use the instrumented queue
+        } yield ()
+      }
+    }
+}
+```
 
 ## Trace - getting started
 

--- a/modules/metrics/shared/src/main/scala/org/typelevel/otel4s/experimental/metrics/InstrumentedQueue.scala
+++ b/modules/metrics/shared/src/main/scala/org/typelevel/otel4s/experimental/metrics/InstrumentedQueue.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.experimental.metrics
+
+import cats.effect.MonadCancelThrow
+import cats.effect.std.Queue
+import cats.syntax.applicative._
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.metrics.Meter
+
+object InstrumentedQueue {
+
+  /** Instruments the given queue.
+    *
+    * The provided metrics:
+    *   - `cats.effect.std.queue.size` - the current number of the elements in the queue
+    *   - `cats.effect.std.queue.enqueued` - the total (lifetime) number of enqueued elements
+    *   - `cats.effect.std.queue.offer.blocked` - the current number of the 'blocked' offerers
+    *   - `cats.effect.std.queue.take.blocked`- the current number of the 'blocked' takers
+    *
+    * @example
+    *   {{{
+    * implicit val meter: Meter[IO] = ???
+    *
+    * val attributes = Attributes(
+    *   Attribute("queue.type", "bounded"),
+    *   Attribute("queue.capacity", 200L),
+    *   Attribute("queue.name", "auth events")
+    * )
+    *
+    * for {
+    *   source <- Queue.bounded[IO, String](200)
+    *   queue <- InstrumentedQueue(source, attributes = attributes)
+    * } yield ()
+    *   }}}
+    *
+    * @param prefix
+    *   the prefix to use with the metrics
+    *
+    * @param attributes
+    *   the attributes to add to the
+    *
+    * @param queue
+    *   the queue to instrument
+    */
+  def apply[F[_]: MonadCancelThrow: Meter, A](
+      queue: Queue[F, A],
+      prefix: String = "cats.effect.std.queue",
+      attributes: Attributes = Attributes.empty
+  ): F[Queue[F, A]] =
+    for {
+      queueSize <- Meter[F]
+        .upDownCounter[Long](s"$prefix.size")
+        .withDescription("The current number of the elements in the queue")
+        .withUnit("{element}")
+        .create
+
+      enqueued <- Meter[F]
+        .counter[Long](s"$prefix.enqueued")
+        .withDescription("The total number of the elements enqueued into the queue")
+        .withUnit("{element}")
+        .create
+
+      offerBlocked <- Meter[F]
+        .upDownCounter[Long](s"$prefix.offer.blocked")
+        .withDescription("The current number of 'blocked' offer operations")
+        .create
+
+      takeBlocked <- Meter[F]
+        .upDownCounter[Long](s"$prefix.take.blocked")
+        .withDescription("The current number of 'blocked' take operations")
+        .create
+
+      initialSize <- queue.size
+      _ <- queueSize.add(initialSize.toLong, attributes)
+      _ <- enqueued.add(initialSize.toLong, attributes)
+    } yield new Queue[F, A] {
+      def offer(a: A): F[Unit] =
+        MonadCancelThrow[F].bracket(offerBlocked.inc(attributes)) { _ =>
+          queue.offer(a) *> enqueued.inc(attributes) *> queueSize.inc(attributes)
+        }(_ => offerBlocked.dec(attributes))
+
+      def tryOffer(a: A): F[Boolean] =
+        queue.tryOffer(a).flatTap { offered =>
+          (enqueued.inc(attributes) *> queueSize.inc(attributes)).whenA(offered)
+        }
+
+      def take: F[A] =
+        MonadCancelThrow[F].bracket(takeBlocked.inc(attributes)) { _ =>
+          queue.take <* queueSize.dec(attributes)
+        }(_ => takeBlocked.dec(attributes))
+
+      def tryTake: F[Option[A]] =
+        queue.tryTake.flatTap(available => queueSize.dec(attributes).whenA(available.isDefined))
+
+      def size: F[Int] =
+        queue.size
+    }
+
+}

--- a/modules/metrics/shared/src/test/scala/org/typelevel/otel4s/experimental/metrics/InstrumentedQueueSuite.scala
+++ b/modules/metrics/shared/src/test/scala/org/typelevel/otel4s/experimental/metrics/InstrumentedQueueSuite.scala
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.experimental.metrics
+
+import cats.effect.IO
+import cats.effect.std.Queue
+import munit.CatsEffectSuite
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
+import org.typelevel.otel4s.sdk.metrics.data.PointData.LongNumber
+import org.typelevel.otel4s.sdk.testkit.metrics.MetricsTestkit
+
+import scala.concurrent.duration._
+
+class InstrumentedQueueSuite extends CatsEffectSuite {
+
+  test("record offered and taken elements") {
+    MetricsTestkit.inMemory[IO]().use { testkit =>
+      testkit.meterProvider.get("meter").flatMap { implicit meter: Meter[IO] =>
+        val expected1 = List(
+          Metric("cats.effect.std.queue.enqueued", "{element}", Nil, 5L),
+          Metric("cats.effect.std.queue.offer.blocked", "", Nil, 0L),
+          Metric("cats.effect.std.queue.size", "{element}", Nil, 5L)
+        )
+
+        val expected2 = List(
+          Metric("cats.effect.std.queue.enqueued", "{element}", Nil, 5L),
+          Metric("cats.effect.std.queue.offer.blocked", "", Nil, 0L),
+          Metric("cats.effect.std.queue.size", "{element}", Nil, 0L),
+          Metric("cats.effect.std.queue.take.blocked", "", Nil, 0L)
+        )
+
+        val element = "value"
+
+        for {
+          source <- Queue.unbounded[IO, String]
+          queue <- InstrumentedQueue(source)
+
+          _ <- queue.offer(element).replicateA_(5)
+          _ <- testkit.collectMetrics.map(toMetrics).assertEquals(expected1)
+
+          _ <- queue.take.replicateA_(5)
+          _ <- testkit.collectMetrics.map(toMetrics).assertEquals(expected2)
+        } yield ()
+      }
+    }
+  }
+
+  test("recorded blocked takers") {
+    MetricsTestkit.inMemory[IO]().use { testkit =>
+      testkit.meterProvider.get("meter").flatMap { implicit meter: Meter[IO] =>
+        val expected1 = List(
+          Metric("cats.effect.std.queue.enqueued", "{element}", Nil, 0L),
+          Metric("cats.effect.std.queue.size", "{element}", Nil, 0L),
+          Metric("cats.effect.std.queue.take.blocked", "", Nil, 1L)
+        )
+
+        val expected2 = List(
+          Metric("cats.effect.std.queue.enqueued", "{element}", Nil, 1L),
+          Metric("cats.effect.std.queue.offer.blocked", "", Nil, 0L),
+          Metric("cats.effect.std.queue.size", "{element}", Nil, 0L),
+          Metric("cats.effect.std.queue.take.blocked", "", Nil, 0L)
+        )
+
+        val element = "value"
+
+        for {
+          source <- Queue.bounded[IO, String](2)
+          queue <- InstrumentedQueue(source)
+
+          fiber <- queue.take.start
+          _ <- IO.sleep(100.millis)
+          _ <- testkit.collectMetrics.map(toMetrics).assertEquals(expected1)
+
+          _ <- queue.offer(element)
+          _ <- fiber.joinWithNever
+
+          _ <- testkit.collectMetrics.map(toMetrics).assertEquals(expected2)
+        } yield ()
+      }
+    }
+  }
+
+  test("recorded blocked offerers") {
+    MetricsTestkit.inMemory[IO]().use { testkit =>
+      testkit.meterProvider.get("meter").flatMap { implicit meter: Meter[IO] =>
+        val expected1 = List(
+          Metric("cats.effect.std.queue.enqueued", "{element}", Nil, 2L),
+          Metric("cats.effect.std.queue.offer.blocked", "", Nil, 1L),
+          Metric("cats.effect.std.queue.size", "{element}", Nil, 2L)
+        )
+
+        val expected2 = List(
+          Metric("cats.effect.std.queue.enqueued", "{element}", Nil, 3L),
+          Metric("cats.effect.std.queue.offer.blocked", "", Nil, 0L),
+          Metric("cats.effect.std.queue.size", "{element}", Nil, 0L),
+          Metric("cats.effect.std.queue.take.blocked", "", Nil, 0L)
+        )
+
+        val element = "value"
+
+        for {
+          source <- Queue.bounded[IO, String](2)
+          queue <- InstrumentedQueue(source)
+
+          fiber <- queue.offer(element).replicateA_(3).start
+          _ <- IO.sleep(100.millis)
+          _ <- testkit.collectMetrics.map(toMetrics).assertEquals(expected1)
+
+          _ <- queue.take.replicateA_(3)
+          _ <- fiber.joinWithNever
+
+          _ <- testkit.collectMetrics.map(toMetrics).assertEquals(expected2)
+        } yield ()
+      }
+    }
+  }
+
+  test("use provided attributes and prefix") {
+    MetricsTestkit.inMemory[IO]().use { testkit =>
+      testkit.meterProvider.get("meter").flatMap { implicit meter: Meter[IO] =>
+        val capacity = 5
+        val prefix = "prefix"
+        val attributes = Attributes(
+          Attribute("queue.type", "bounded"),
+          Attribute("queue.capacity", capacity.toLong),
+          Attribute("queue.name", "auth events")
+        )
+        val attributesKeys = attributes.toList.map(_.key.name)
+
+        val expected1 = List(
+          Metric(s"$prefix.enqueued", "{element}", attributesKeys, capacity.toLong),
+          Metric(s"$prefix.offer.blocked", "", attributesKeys, 0L),
+          Metric(s"$prefix.size", "{element}", attributesKeys, capacity.toLong)
+        )
+
+        val expected2 = List(
+          Metric("prefix.enqueued", "{element}", attributesKeys, capacity.toLong),
+          Metric("prefix.offer.blocked", "", attributesKeys, 0L),
+          Metric("prefix.size", "{element}", attributesKeys, 0L),
+          Metric("prefix.take.blocked", "", attributesKeys, 0L)
+        )
+
+        val element = ""
+
+        for {
+          source <- Queue.unbounded[IO, String]
+          queue <- InstrumentedQueue(source, prefix, attributes)
+
+          _ <- queue.offer(element).replicateA_(capacity)
+          _ <- testkit.collectMetrics.map(toMetrics).assertEquals(expected1)
+
+          _ <- queue.take.replicateA_(capacity)
+          _ <- testkit.collectMetrics.map(toMetrics).assertEquals(expected2)
+        } yield ()
+      }
+    }
+  }
+
+  test("respect initial size") {
+    MetricsTestkit.inMemory[IO]().use { testkit =>
+      testkit.meterProvider.get("meter").flatMap { implicit meter: Meter[IO] =>
+        val capacity = 5
+
+        val expected = List(
+          Metric("cats.effect.std.queue.enqueued", "{element}", Nil, capacity.toLong),
+          Metric("cats.effect.std.queue.size", "{element}", Nil, capacity.toLong)
+        )
+
+        val element = ""
+
+        for {
+          source <- Queue.unbounded[IO, String]
+          _ <- source.offer(element).replicateA_(capacity)
+          _ <- InstrumentedQueue(source)
+          _ <- testkit.collectMetrics.map(toMetrics).assertEquals(expected)
+        } yield ()
+      }
+    }
+  }
+
+  private case class Metric(name: String, unit: String, attributesKeys: List[String], value: Long)
+
+  private def toMetrics(metrics: List[MetricData]): List[Metric] =
+    metrics.sortBy(_.name).map { md =>
+      val (keys, value) = md.data match {
+        case sum: MetricPoints.Sum =>
+          sum.points.head match {
+            case long: LongNumber =>
+              (long.attributes.map(_.key.name), long.value)
+            case _ =>
+              sys.error("long expected")
+          }
+
+        case gauge: MetricPoints.Gauge =>
+          gauge.points.head match {
+            case long: LongNumber =>
+              (long.attributes.map(_.key.name), long.value)
+            case _ =>
+              sys.error("long expected")
+          }
+
+        case _: MetricPoints.Histogram =>
+          sys.error("gauge or sum expected")
+      }
+
+      Metric(md.name, md.unit.getOrElse(""), keys.toList, value)
+    }
+
+}


### PR DESCRIPTION
A simple way to instrument `cats.effect.std.Queue`.

The provided metrics:
  - `cats.effect.std.queue.size` - the current number of the elements in the queue
  - `cats.effect.std.queue.enqueued` - the total (lifetime) number of enqueued elements
  - `cats.effect.std.queue.offer.blocked` - the current number of the 'blocked' offerers
  - `cats.effect.std.queue.take.blocked`- the current number of the 'blocked' takers